### PR TITLE
Fix: clear `elements` property

### DIFF
--- a/connect/SFtpManager.php
+++ b/connect/SFtpManager.php
@@ -11,7 +11,7 @@ define('NET_SFTP_LOGGING', 'NET_SFTP_LOG_COMPLEX');
 /**
  * Class SFtpManager
  *
- * @mixin SFTP;
+ * @mixin SFTP
  *
  * @package Vandzaxe
  */

--- a/connect/SFtpManager.php
+++ b/connect/SFtpManager.php
@@ -65,6 +65,8 @@ class SFtpManager extends Component
      */
     public function scanDir($dir = ".", $recursive = false)
     {
+        $this->elements = [];
+        
         $list = $this->connect->rawlist($dir, $recursive);
         usort($list, function ($attr) {
             return ($attr["type"] == self::TYPE_DIR) ? 0 : 1;


### PR DESCRIPTION
When Scandir() is called multiple times within a single sFTP session, `$this->elements` still contains the elements from the previous call(s) to Scandir().